### PR TITLE
Clarify Comment Notation in LSTM Example to Resolve Ambiguity (Fixes #2)

### DIFF
--- a/rnn-lstm-gru/main.py
+++ b/rnn-lstm-gru/main.py
@@ -57,22 +57,22 @@ class RNN(nn.Module):
         h0 = torch.zeros(self.num_layers, x.size(0), self.hidden_size).to(device) 
         #c0 = torch.zeros(self.num_layers, x.size(0), self.hidden_size).to(device) 
         
-        # x: (n, 28, 28), h0: (2, n, 128)
+        # x: (batch_size, sequence_length=28, input_size=28), h0: (num_layers=2, batch_size, hidden_size=128)
         
         # Forward propagate RNN
         out, _ = self.rnn(x, h0)  
         # or:
         #out, _ = self.lstm(x, (h0,c0))  
         
-        # out: tensor of shape (batch_size, seq_length, hidden_size)
-        # out: (n, 28, 128)
+        # out: tensor of shape (batch_size, sequence_length, hidden_size)
+        # out: (batch_size, 28, 128)
         
         # Decode the hidden state of the last time step
         out = out[:, -1, :]
-        # out: (n, 128)
+        # out: (batch_size, hidden_size=128)
          
         out = self.fc(out)
-        # out: (n, 10)
+        # out: (batch_size, num_classes=10)
         return out
 
 model = RNN(input_size, hidden_size, num_layers, num_classes).to(device)
@@ -85,8 +85,8 @@ optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
 n_total_steps = len(train_loader)
 for epoch in range(num_epochs):
     for i, (images, labels) in enumerate(train_loader):  
-        # origin shape: [N, 1, 28, 28]
-        # resized: [N, 28, 28]
+        # origin shape: [batch_size, 1, 28, 28]
+        # resized: [batch_size, sequence_length=28, input_size=28]
         images = images.reshape(-1, sequence_length, input_size).to(device)
         labels = labels.to(device)
         


### PR DESCRIPTION
# Pull Request Description

### Overview
This pull request addresses issue #2 regarding the inconsistent and ambiguous comment notation in the LSTM example code. The changes implemented are aimed at enhancing the clarity of the code, making it more accessible for learners and practitioners who refer to the LSTM implementation for guidance.

### Changes Made
1. **Replaced Confusing Notations**: All instances of 'n' and 'N' have been replaced with the explicit term **'batch_size'** to eliminate ambiguity and improve understanding of the batch size and its context.
  
2. **Detailed Comments**: Added comprehensive explanations and explicit dimension names in the tensor shape comments throughout the code. This includes specifying the meaning of different dimensions in operations involving tensors and hidden states.
  
3. **Consistency in Notation**: Ensured that the presentation of tensor shapes is consistent throughout the file, making it easier to follow the structure of the data being processed.
  
4. **Clarified Input and Output Shapes**: Provided detailed descriptions of expected input and output shapes for various layers, particularly focusing on the shapes of hidden states and outputs to clarify the transition between different stages of LSTM processing.

### Rationale
The changes made are designed to reduce confusion regarding tensor dimensions, particularly in relation to batch size and hidden state dimensions. This should significantly improve the learning experience for users who are utilizing the LSTM example code to understand and implement their own models.

### Additional Information
The adjustments are a direct response to feedback from the community, and we appreciate the insights shared by users such as the individual who raised this issue. If there are any further questions or requests for clarification on the changes, please feel free to reach out.

**Fixes #2**

Thank you for your engagement, and we hope these improvements prove beneficial to your learning journey with PyTorch and neural networks!